### PR TITLE
Add BUNDLE DESTINATION to support cross compiling for iOS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -526,6 +526,7 @@ if(HAVE_GETOPT_LONG)
 
     install(TARGETS xzdec
             RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}"
+            BUNDLE  DESTINATION "${CMAKE_INSTALL_BINDIR}"
                     COMPONENT xzdec)
 
     if(UNIX)
@@ -653,6 +654,7 @@ if(NOT MSVC AND HAVE_GETOPT_LONG)
 
     install(TARGETS xz
             RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}"
+            BUNDLE  DESTINATION "${CMAKE_INSTALL_BINDIR}"
                     COMPONENT xz)
 
     install(FILES src/xz/xz.1


### PR DESCRIPTION
We are compiling liblzma for iOS using vcpkg.  We received the following errors:

```
CMake Error at CMakeLists.txt:527 (install):
  install TARGETS given no BUNDLE DESTINATION for MACOSX_BUNDLE executable
  target "xzdec".

CMake Error at CMakeLists.txt:654 (install):
  install TARGETS given no BUNDLE DESTINATION for MACOSX_BUNDLE executable
  target "xz".
```

After some sleuthing, we discovered this similar issue affecting another library
* https://gitlab.com/BenjaminDobell/Heimdall/-/issues/480

After forking your project and applying a similar change, we are able to build liblzma for iOS using vcpkg.

If you merge this pull request, we'll also submit a PR to vcpkg to update the reference to the updated liblzma source code.

thanks!
